### PR TITLE
Capitalize Elixir utilities file in module name require.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var imagemin = require('gulp-imagemin');
 var pngquant = require('imagemin-pngquant');
 var notify = require('gulp-notify');
 var _ = require('underscore');
-var utilities = require('laravel-elixir/ingredients/commands/utilities');
+var utilities = require('laravel-elixir/ingredients/commands/Utilities');
 
 /*
  |----------------------------------------------------------------


### PR DESCRIPTION
The utilifies file on Elixir is uppercased so it's throwing the error 'Error: Cannot find module 'laravel-elixir/ingredients/commands/utilities' when running gulp. This small change fixes it.
