### PR TITLE
[Add] Gulp-changed dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var elixir = require('laravel-elixir');
 var gulp = require('gulp');
+var changed = require('gulp-changed');
 var imagemin = require('gulp-imagemin');
 var pngquant = require('imagemin-pngquant');
 var notify = require('gulp-notify');
@@ -34,6 +35,7 @@ elixir.extend('imagemin', function(src, output, options) {
 
     gulp.task('imagemin', function() {
         return gulp.src(src)
+            .pipe(changed(output || 'public/img'))
             .pipe(imagemin(options))
             .pipe(gulp.dest(output || 'public/img'))
             .on('error', notify.onError({

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "url": "https://github.com/nathanmac/laravel-elixir-imagemin"
   },
   "dependencies": {
+    "gulp-changed": "^1.1.1",
     "gulp-imagemin": "^1.2.0",
-    "imagemin-pngquant": "^4.0.0",
     "gulp-notify": "^2.0.0",
+    "imagemin-pngquant": "^4.0.0",
     "underscore": "^1.7.0"
   }
 }


### PR DESCRIPTION
laravel-elixir-imagemin now ignore unchanged images for a faster gulp process.
