### PR TITLE
Modify default src directory && Condense watcher task

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,13 +44,7 @@ elixir.extend('imagemin', function(src, output, options) {
             }));
     });
 
-    this.registerWatcher('imagemin', [
-        baseDir + '/**/*.png',
-        baseDir + '/**/*.gif',
-        baseDir + '/**/*.svg',
-        baseDir + '/**/*.jpg',
-        baseDir + '/**/*.jpeg'
-    ]);
+    this.registerWatcher('imagemin', baseDir + '/**/*.{png,gif,svg,jpg,jpeg}');
 
     return this.queueTask('imagemin');
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ elixir.extend('imagemin', function(src, output, options) {
 
     var config = this;
 
-    var baseDir = config.assetsDir + 'img';
+    // default to: 'resources/assets/images'
+    var baseDir = config.assetsDir + 'images';
 
     src = utilities.buildGulpSrc(src, baseDir, '**/*');
 


### PR DESCRIPTION
Default to 'resources/assets/images' instead of 'resources/assets/img'.

Compress watcher task's sources into one line.
