### PR TITLE
Fix `gulp watch` for custom directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,25 +17,23 @@ var config   = elixir.config;
  | Minify PNG, JPEG, GIF and SVG images
  |
  */
-elixir.extend('imagemin', function(src, output, options) {
+elixir.extend('imagemin', function(options) {
 
-    config.images = {
+    config.images = _.extend({
         folder: 'images',
-        outputFolder: 'images',
+        outputFolder: 'images'
+    }, config.images || {});
 
-        pluginOptions: {
-            progressive: true,
-            svgoPlugins: [{removeViewBox: false}],
-            use: [pngquant()]
-        }
-    };
-
-    options = _.extend(config.images.pluginOptions, options);
+    options = _.extend({
+        progressive: true,
+        svgoPlugins: [{removeViewBox: false}],
+        use: [pngquant()]
+    }, options);
 
     new elixir.Task('imagemin', function () {
         var paths = new elixir.GulpPaths()
-            .src(src || config.get('assets.images.folder'))
-            .output(output || config.get('public.images.outputFolder'));
+            .src(config.get('assets.images.folder'))
+            .output(config.get('public.images.outputFolder'));
 
         return gulp.src(paths.src.path)
             .pipe(changed(paths.output.path))

--- a/readme.md
+++ b/readme.md
@@ -22,23 +22,72 @@ elixir(function(mix) {
 });
 ```
 
-This will scan your `resources/assets/images` directory for all image files. Instead, if you only want to process a
-different directory, you may do:
+This will scan your `resources/assets/images` directory for all image files.
+
+### Changing the default image directories
+
+If you want to process a different image directory, you can update your Elixir config by either:
+
+#### Defining `elixir.config.images` in your *Gulpfile*
+
+You can define `elixir.config.images` in your `gulpfile.js` like so:
 
 ```javascript
-mix.imagemin("./resources/assets/img");
+var elixir = require('laravel-elixir');
+
+require('laravel-elixir-imagemin');
+
+elixir.config.images = {
+    folder: 'img',
+    outputFolder: 'img'
+};
+
+elixir(function(mix) {
+   mix.imagemin();
+});
 ```
 
-Finally, if you'd like to output to a different directory than the default public/images, then you may override this as well.
+#### Setting `config.images` in an `elixir.json` file
+
+You can create an [`elixir.json`](https://github.com/laravel/elixir/blob/dfd6655537eb3294a4c71e826cd0e8a6f6b2108b/index.js#L50-L67)
+file in your project root to modify Elixir's default settings.
+
+```json
+{
+    "images": {
+        "folder": "img",
+        "outputFolder": "img"
+    }
+}
+```
+
+#### Upgrading from the old syntax
+
+If you're upgrading from the old syntax, where you defined custom directories like so:
 
 ```javascript
 mix.imagemin("./resources/assets/img", "public/images/foo/bar/");
 ```
 
-#### Advanced example
+All you have to do is:
 
-In third argument you could pass imagemin options.
+- Remove the first two parameters, then
+- Follow the instructions for ["Changing the default image directories"](#changing-the-default-image-directories)
+
+**Note**: You don't define the full path anymore. Instead of `resources/assets/img` you simply use `img`, because
+laravel-elixir-imagemin will look inside your `assets` and `public` directories (or whatever else you may have
+configured).
+
+### Custom imagemin options
+
+You can override the default imagemin options by passing in an options object like so:
 
 ```javascript
-mix.imagemin("./resources/assets/img", "public/img", { optimizationLevel: 3, progressive: true, interlaced: true });
+mix.imagemin({
+    optimizationLevel: 3,
+    progressive: true,
+    interlaced: true
+});
 ```
+
+Available imagemin options are listed [here in the gulp-imagemin readme](https://github.com/sindresorhus/gulp-imagemin#imageminoptions).


### PR DESCRIPTION
## tl;dr

`gulp watch` doesn’t work with custom image directories. This fixes that by extending `config.images` instead of hard-coding it.
## Problem

The custom `src` and `output` paths work great when you run imagemin as an individual task, but they aren’t reflected in the `watch` task.

For example, if I use:

```
mix.imagemin("./resources/assets/img", "public/img”);
```

When I run `gulp watch` it ends up just watching the `images` directory because [`config.images` is hard-coded in](https://github.com/nathanmac/laravel-elixir-imagemin/blob/25283a43242c2c1d4ec422d6a53babd75d5d9494/index.js#L22-L24).
## Solution

Instead of hard-coding the `config.images`, extend it.

This way users can customize their Elixir settings the same as you would for the default [css](https://github.com/laravel/elixir/blob/58c43723f6eab8bc920fce48e498640d481e2aca/Config.js#L117) and [js](https://github.com/laravel/elixir/blob/58c43723f6eab8bc920fce48e498640d481e2aca/Config.js#L226) settings: either in your `gulpfile.js` or in an `elixir.json` file.

The `src` and `output` arguments end up becoming unnecessary, so I’ve dropped them. Now you only pass in plugin options (if needed).

The advantages of this:
- More configurable settings
- A cleaner, more consistent API

Plus, if you want to use the defaults but override the plugin options now you don’t have to add two dummy arguments.
## Upgrading

This update only affects users with custom directories: it still defaults to `images`, even if you don’t have `config.images` setup anywhere else. No upgrade pains.

For users who are using custom directories, I’ve added upgrade notes to the readme to make things easier.
