### PR TITLE
Upgrade the gulp-imagemin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "gulp-changed": "^1.3.0",
-    "gulp-imagemin": "^2.3.0",
+    "gulp-imagemin": "^3.0.2",
     "imagemin-pngquant": "^4.1.2",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
With the dependency version of the gulp-imagemin i receive this error in my machinte (I'm running laravel in a valet server):

var charCode = isBuf ? buf[i] : buf.charCodeAt(i);
TypeError: Cannot read property 'charCodeAt' of undefined

I upgrade the library ant the problem was solved.
